### PR TITLE
Add OpenAPI definitions, Swagger UI and Redoc

### DIFF
--- a/dandi/settings.py
+++ b/dandi/settings.py
@@ -220,7 +220,9 @@ class CorsConfig(Config):
 class RestFrameworkConfig(Config):
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
-        configuration.INSTALLED_APPS += ['rest_framework', 'rest_framework.authtoken']
+        configuration.INSTALLED_APPS += ['rest_framework',
+                                         'rest_framework.authtoken',
+                                         'drf_yasg']
 
     REST_FRAMEWORK = {
         'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication']

--- a/dandi/urls.py
+++ b/dandi/urls.py
@@ -1,7 +1,10 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+from rest_framework import permissions
 from rest_framework_extensions.routers import ExtendedSimpleRouter
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from publish.views import AssetViewSet, DandisetViewSet, VersionViewSet
 
@@ -26,9 +29,21 @@ router = ExtendedSimpleRouter()
     )
 )
 
+schema_view = get_schema_view(
+    openapi.Info(
+        title='ABC',
+        default_version='v1',
+        description='abc123',
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,)
+)
+
 urlpatterns = [
     path('api/', include(router.urls)),
     path('admin/', admin.site.urls),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc')
 ]
 
 if settings.DEBUG:

--- a/dandi/urls.py
+++ b/dandi/urls.py
@@ -31,12 +31,12 @@ router = ExtendedSimpleRouter()
 
 schema_view = get_schema_view(
     openapi.Info(
-        title='ABC',
+        title='DANDI Archive',
         default_version='v1',
-        description='abc123',
+        description='The BRAIN Initiative archive for publishing and sharing cellular neurophysiology data',
     ),
     public=True,
-    permission_classes=(permissions.AllowAny,)
+    permission_classes=[permissions.AllowAny]
 )
 
 urlpatterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ django-extensions
 djangorestframework
 drf-extensions
 drf-yasg
-future
 httpx
 psycopg2
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,12 @@ django-cors-headers
 django-extensions
 djangorestframework
 drf-extensions
+drf-yasg
+future
 httpx
 psycopg2
 pyyaml
 whitenoise[brotli]
-future
 
 django-stubs
 djangorestframework-stubs


### PR DESCRIPTION
Use the `drf-yasg` extension to provide OpenAPI definitions.

Render the default Swagger UI and Redoc UI pages. Redoc is a 3rd party
OpenAPI consumer that is included so we can try both to see how they
fit.