### PR TITLE
Remove future requirement, as Celery has been updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ httpx
 psycopg2
 pyyaml
 whitenoise[brotli]
-future
 
 django-stubs
 djangorestframework-stubs


### PR DESCRIPTION
Celery 4.4.5 adds this missing requirement: https://github.com/celery/celery/releases/tag/v4.4.5