### PR TITLE
Lock the dandiset during publish

### DIFF
--- a/dandi/settings.py
+++ b/dandi/settings.py
@@ -351,6 +351,7 @@ class DandiConfig(Config):
 
     DANDI_DANDISETS_BUCKET_NAME = values.Value(environ_required=True)
     DANDI_GIRDER_API_URL = values.URLValue(environ_required=True)
+    DANDI_GIRDER_API_KEY = values.Value(environ_required=True)
 
 
 class BaseConfiguration(

--- a/publish/tasks.py
+++ b/publish/tasks.py
@@ -3,7 +3,7 @@ from celery.utils.log import get_task_logger
 from django.db.transaction import atomic
 
 from publish.models import Asset, Dandiset, Version
-from .girder import GirderClient
+from .girder import GirderClient, dandiset_lock
 
 
 logger = get_task_logger(__name__)
@@ -18,9 +18,10 @@ def sync_dandiset(draft_folder_id: str) -> None:
 @shared_task
 @atomic
 def publish_version(dandiset_id: int) -> None:
-    with GirderClient() as client:
+    with GirderClient(authenticate=True) as client:
         dandiset = Dandiset.objects.get(pk=dandiset_id)
-        version = Version.from_girder(dandiset, client)
+        with dandiset_lock(dandiset.identifier, client):
+            version = Version.from_girder(dandiset, client)
 
-        for girder_file in client.files_in_folder(dandiset.draft_folder_id):
-            Asset.from_girder(version, girder_file, client)
+            for girder_file in client.files_in_folder(dandiset.draft_folder_id):
+                Asset.from_girder(version, girder_file, client)


### PR DESCRIPTION
- Add a new environment variable `DJANGO_DANDI_GIRDER_API_KEY` which
contains the API key for a Girder user dedicated to publishing. This
robo-user is used to lock the dandiset being published.
- Tweak `GirderClient` to optionally authenticate with the API key and
append the Girder auth token to all subsequent requests.
- Add a helper `dandiset_lock` which is used in a `with` statement to
lock and unlock a dandiset.
- Invoke `dandiset_lock` from the `publish_version` task.