### PR TITLE
Make sync synchronous instead of celery task

### DIFF
--- a/publish/tasks.py
+++ b/publish/tasks.py
@@ -10,12 +10,6 @@ logger = get_task_logger(__name__)
 
 
 @shared_task
-def sync_dandiset(draft_folder_id: str) -> None:
-    with GirderClient() as client:
-        Dandiset.from_girder(draft_folder_id, client)
-
-
-@shared_task
 @atomic
 def publish_version(dandiset_id: int) -> None:
     with GirderClient() as client:

--- a/publish/views/dandiset.py
+++ b/publish/views/dandiset.py
@@ -8,8 +8,8 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 
+from publish.girder import GirderClient
 from publish.models import Dandiset
-from publish.tasks import sync_dandiset
 from publish.views.common import DandiPagination
 
 
@@ -56,5 +56,6 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             raise ValidationError('Missing query parameter "folder-id"')
         draft_folder_id = request.query_params['folder-id']
 
-        sync_dandiset.delay(draft_folder_id)
+        with GirderClient() as client:
+            Dandiset.from_girder(draft_folder_id, client)
         return Response('', status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
The sync action was originally a celery task so that the API did not
have to block on any database operations. This is inconvenient when
syncing immediately before a publish. The sync request would return, but
the celery task was still queued, so immediately performing a publish
would fail because the database had not yet been synced.

The sync endpoint now blocks until the sync is complete.