### PR TITLE
Clean up style of "dandiset_lock"

### DIFF
--- a/publish/girder.py
+++ b/publish/girder.py
@@ -75,14 +75,14 @@ class GirderClient(Client):
             yield resp.iter_bytes()
 
 
-@contextlib.contextmanager
-def dandiset_lock(dandiset_id, client: GirderClient):
-    resp = client.post(f'dandi/{dandiset_id}/lock')
-    if (resp.status_code != 200):
-        raise GirderError(f'Failed to lock dandiset {dandiset_id}')
-    try:
-        yield
-    finally:
-        resp = client.post(f'dandi/{dandiset_id}/unlock')
-        if (resp.status_code != 200):
-            raise GirderError(f'Failed to unlock dandiset {dandiset_id}')
+    @contextlib.contextmanager
+    def dandiset_lock(self, dandiset_identifier: str):
+        resp = self.post(f'dandi/{dandiset_identifier}/lock')
+        if resp.status_code != 200:
+            raise GirderError(f'Failed to lock dandiset {dandiset_identifier}')
+        try:
+            yield
+        finally:
+            resp = self.post(f'dandi/{dandiset_identifier}/unlock')
+            if resp.status_code != 200:
+                raise GirderError(f'Failed to unlock dandiset {dandiset_identifier}')

--- a/publish/tasks.py
+++ b/publish/tasks.py
@@ -14,7 +14,7 @@ logger = get_task_logger(__name__)
 def publish_version(dandiset_id: int) -> None:
     with GirderClient(authenticate=True) as client:
         dandiset = Dandiset.objects.get(pk=dandiset_id)
-        with dandiset_lock(dandiset.identifier, client):
+        with client.dandiset_lock(dandiset.identifier):
             version = Version.from_girder(dandiset, client)
 
             for girder_file in client.files_in_folder(dandiset.draft_folder_id):


### PR DESCRIPTION
* Make it method of GirderClient
* Rename and add type hint for the "dandiset_id" parameter
  * A "*_id" generally indicates a model's primary key, which is an int
* Remove unnecessary parenthesis