### PR TITLE
Add asset download endpoint, and change asset path filter mode

### DIFF
--- a/publish/views/asset.py
+++ b/publish/views/asset.py
@@ -35,8 +35,6 @@ class AssetDetailSerializer(AssetSerializer):
 
 
 class AssetFilter(filters.FilterSet):
-    path = filters.CharFilter(lookup_expr='exact', field_name='path')
-
     class Meta:
         model = Asset
         fields = ['path']

--- a/publish/views/asset.py
+++ b/publish/views/asset.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponseRedirect
 from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.decorators import action
@@ -55,6 +56,11 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = AssetFilter
+
+    @action(detail=True, methods=['GET'])
+    def download(self, request, **kwargs):
+        """Return a redirect to the file download in S3."""
+        return HttpResponseRedirect(redirect_to=self.get_object().blob.url)
 
     @action(detail=False, methods=['GET'])
     def paths(self, request, **kwargs):

--- a/publish/views/asset.py
+++ b/publish/views/asset.py
@@ -59,7 +59,7 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     @action(detail=True, methods=['GET'])
     def download(self, request, **kwargs):
-        """Return a redirect to the file download in S3."""
+        """Return a redirect to the file download in the object store."""
         return HttpResponseRedirect(redirect_to=self.get_object().blob.url)
 
     @action(detail=False, methods=['GET'])

--- a/publish/views/asset.py
+++ b/publish/views/asset.py
@@ -34,11 +34,11 @@ class AssetDetailSerializer(AssetSerializer):
 
 
 class AssetFilter(filters.FilterSet):
-    path_prefix = filters.CharFilter(lookup_expr='startswith', field_name='path')
+    path = filters.CharFilter(lookup_expr='exact', field_name='path')
 
     class Meta:
         model = Asset
-        fields = ['path_prefix']
+        fields = ['path']
 
 
 class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):


### PR DESCRIPTION
Fixes #52.

The reason for changing the lookup mode of the `path_prefix` AssetFilter field (now just `path`), is because:
* It wasn't being used for prefix searching
* It's needed for use by the frontend when fetching the download link for a given asset path (i.e. turning a path to an asset into the actual asset information).