### PR TITLE
First draft of API tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from setuptools import setup
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+requirements = [
+    'boto3',
+    'celery',
+    'dandi',
+    'dj-database-url',
+    'django',
+    'django-admin-display',
+    'django-configurations',
+    'django-cors-headers',
+    'django-debug-toolbar',
+    'django-extensions',
+    'django-filter',
+    'django-minio-storage',
+    'django-storages',
+    'djangorestframework',
+    'drf-extensions',
+    'drf-yasg',
+    'httpx',
+    'psycopg2',
+    'pyyaml',
+    'whitenoise',
+]
+
+setup(
+    python_requires='>=3.8.0',
+    install_requires=requirements,
+    license='Apache Software License 2.0',
+    long_description=readme,
+    long_description_content_type='text/x-md',
+    name='dandi_publish',
+    version='0.1.0',
+)

--- a/test/fuzzy.py
+++ b/test/fuzzy.py
@@ -1,0 +1,23 @@
+import re
+
+
+class Re:
+    def __init__(self, pattern):
+        if isinstance(pattern, type(re.compile(""))):
+            self.pattern = pattern
+        else:
+            self.pattern = re.compile(pattern)
+
+    def __eq__(self, other):
+        return self.pattern.fullmatch(other) is not None
+
+    def __str__(self):
+        return self.pattern.pattern
+
+    def __repr__(self):
+        return repr(self.pattern.pattern)
+
+
+class Timestamp(Re):
+    def __init__(self):
+        super().__init__(r"\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z")

--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -1,0 +1,152 @@
+import pytest
+from publish.models import Dandiset, Version, Asset
+from tempfile import NamedTemporaryFile
+from fuzzy import Timestamp
+from django.core.files import File
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def dandiset():
+    dandiset = Dandiset(id='000001', draft_folder_id='abc123')
+    dandiset.save()
+    return dandiset
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def version(dandiset):
+    version = Version(dandiset=dandiset, metadata={'a': 1, 'b': '2', 'c': ['x', 'y', 'z']})
+    version.save()
+    return version
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def asset(version):
+    with NamedTemporaryFile('r+b') as local_stream:
+        blob = File(file=local_stream, name='foo/bar.nwb',)
+        blob.content_type = 'application/octet-stream'
+        asset = Asset(
+            version=version,
+            path='/foo/bar.nwb',
+            size=1337,
+            sha256='sha256',
+            metadata={'foo': ['bar', 'baz']},
+            blob=blob,
+        )
+        asset.save()
+    return asset
+
+
+@pytest.mark.django_db
+def test_dandisets_list(client, dandiset):
+    assert client.get('/api/dandisets/').json() == {
+        'count': 1,
+        'next': None,
+        'previous': None,
+        'results': [
+            {
+                'identifier': '000001',
+                'created': Timestamp(),
+                'updated': Timestamp(),
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+def test_dandisets_read(client, dandiset):
+    assert client.get('/api/dandisets/000001/').json() == {
+        'identifier': '000001',
+        'created': Timestamp(),
+        'updated': Timestamp(),
+    }
+
+
+@pytest.mark.django_db
+def test_dandisets_versions_list(client, dandiset, version):
+    assert client.get('/api/dandisets/000001/versions/').json() == {
+        'count': 1,
+        'next': None,
+        'previous': None,
+        'results': [
+            {
+                'dandiset': {
+                    'identifier': dandiset.identifier,
+                    'created': Timestamp(),
+                    'updated': Timestamp(),
+                },
+                'version': version.version,
+                'created': Timestamp(),
+                'updated': Timestamp(),
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+def test_dandisets_versions_read(client, dandiset, version, asset):
+    assert client.get(f'/api/dandisets/000001/versions/{version.version}/').json() == {
+        'dandiset': {
+            'identifier': dandiset.identifier,
+            'created': Timestamp(),
+            'updated': Timestamp(),
+        },
+        'version': version.version,
+        'created': Timestamp(),
+        'updated': Timestamp(),
+        'metadata': version.metadata,
+    }
+
+
+@pytest.mark.django_db
+def test_dandisets_versions_assets_list(client, dandiset, version, asset):
+    assert client.get(f'/api/dandisets/000001/versions/{version.version}/assets/').json() == {
+        'count': 1,
+        'next': None,
+        'previous': None,
+        'results': [
+            {
+                'version': {
+                    'dandiset': {
+                        'identifier': dandiset.identifier,
+                        'created': Timestamp(),
+                        'updated': Timestamp(),
+                    },
+                    'version': version.version,
+                    'created': Timestamp(),
+                    'updated': Timestamp(),
+                },
+                'uuid': str(asset.uuid),
+                'path': asset.path,
+                'size': asset.size,
+                'sha256': asset.sha256,
+                'created': Timestamp(),
+                'updated': Timestamp(),
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+def test_dandisets_versions_assets_read(client, dandiset, version, asset):
+    assert client.get(f'/api/dandisets/000001/versions/{version.version}/assets/{asset.uuid}/').json() == {
+        'version': {
+            'dandiset': {
+                'identifier': dandiset.identifier,
+                'created': Timestamp(),
+                'updated': Timestamp(),
+            },
+            'version': version.version,
+            'created': Timestamp(),
+            'updated': Timestamp(),
+        },
+        'uuid': str(asset.uuid),
+        'path': asset.path,
+        'size': asset.size,
+        'sha256': asset.sha256,
+        'created': Timestamp(),
+        'updated': Timestamp(),
+        'metadata': asset.metadata,
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,22 @@
 [tox]
 envlist =
     lint,
+    py3,
+
+[testenv]
+setenv =
+    DJANGO_DANDI_DANDISETS_BUCKET_NAME=dandi-dandisets
+    DJANGO_DANDI_GIRDER_API_KEY=abc123
+    DJANGO_DANDI_GIRDER_API_URL=http://localhost/
+    DJANGO_DATABASE_URL=postgres://postgres:postgres@localhost:5432/dandi
+    DJANGO_MINIO_STORAGE_ACCESS_KEY=djangoAccessKey
+    DJANGO_MINIO_STORAGE_SECRET_KEY=djangoSecretKey
+    DJANGO_STORAGE_BUCKET_NAME=dandi-files
+deps =
+    -rrequirements.txt
+    pytest-django
+commands =
+    pytest {posargs}
 
 [testenv:lint]
 skipsdist = true
@@ -56,3 +72,5 @@ ignore =
 [pytest]
 DJANGO_SETTINGS_MODULE = dandi.settings
 DJANGO_CONFIGURATION = DevelopmentConfiguration
+addopts = --verbose --strict --showlocals
+python_files = test_*.py


### PR DESCRIPTION
Running the tests in tox seemed to require a `setup.py` file, so that is
added as well as the test files.

`fuzzy.py` is a very small helper that essentially mocks timestamp
objects to make JSON object comparisons cleaner.