### PR TITLE
Remove dandi-cli from publish workflow

### DIFF
--- a/dandi/publish/models/asset.py
+++ b/dandi/publish/models/asset.py
@@ -76,23 +76,10 @@ class Asset(models.Model):  # TODO: was NwbFile
             # local_path = Path(local_stream.name)
             sha256 = sha256_hasher.hexdigest()
 
-            # try:
-            #     subprocess.check_call(['dandi', 'validate', str(local_path)])
-            # except subprocess.CalledProcessError:
-            #     # TODO: No validation enforcement now
-            #     pass
-
             blob = File(file=local_stream, name=girder_file.path.lstrip('/'),)
             # content_type is not part of the base File class (it on some other subclasses),
             # but regardless S3Boto3Storage will respect and use it, if it's set
             blob.content_type = 'application/octet-stream'
-
-            # s3.put_object(
-            #     Bucket=S3_BUCKET,
-            #     Key=f'{prefix}/dandiset.yaml',
-            #     Body=dump(self.metadata['dandiset']).encode(),
-            #     ACL='public-read',
-            # )
 
             asset = Asset(
                 version=version,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'celery',
-        'dandi==0.4.5',
         'django',
         'django-admin-display',
         'django-configurations[database,email]',


### PR DESCRIPTION
The `dandi` package in `setup.py` refers to the dandi-cli, and conflicts with the local `dandi` package. It was originally used to validate downloaded dandisets prior to publish, but that code isn't being used.