### PR TITLE
Pin Django to 3.0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'celery',
-        'django',
+        'django==3.0.9',
         'django-admin-display',
         'django-configurations[database,email]',
         'django-cors-headers',


### PR DESCRIPTION
Django 3.1.0 breaks some reverse compatibility that drf-extensions
depends on. Until that's resolved, leave Django at 3.0.9.