### PR TITLE
Remove trailing commas from function parameters

### DIFF
--- a/dandi/publish/migrations/0001_initial.py
+++ b/dandi/publish/migrations/0001_initial.py
@@ -124,7 +124,7 @@ class Migration(migrations.Migration):
                 fields=['dandiset', 'version'], name='publish_ver_dandise_5d36c6_idx'
             ),
         ),
-        migrations.AlterUniqueTogether(name='version', unique_together={('dandiset', 'version')},),
+        migrations.AlterUniqueTogether(name='version', unique_together={('dandiset', 'version')}),
         migrations.AddIndex(
             model_name='asset',
             index=models.Index(fields=['uuid'], name='publish_ass_uuid_94d83f_idx'),

--- a/dandi/publish/migrations/0003_asset_ordering.py
+++ b/dandi/publish/migrations/0003_asset_ordering.py
@@ -10,5 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterModelOptions(name='asset', options={'ordering': ['version', 'path']},)
+        migrations.AlterModelOptions(name='asset', options={'ordering': ['version', 'path']})
     ]

--- a/dandi/publish/models/asset.py
+++ b/dandi/publish/models/asset.py
@@ -40,11 +40,11 @@ class Asset(models.Model):  # TODO: was NwbFile
 
     path = models.CharField(max_length=512)
     size = models.BigIntegerField()
-    sha256 = models.CharField(max_length=64, validators=[RegexValidator(f'^{SHA256_REGEX}$')],)
+    sha256 = models.CharField(max_length=64, validators=[RegexValidator(f'^{SHA256_REGEX}$')])
     metadata = JSONField(blank=True, default=dict)
 
     blob = DeconstructableFileField(
-        blank=True, storage=_get_asset_blob_storage, upload_to=_get_asset_blob_prefix,
+        blank=True, storage=_get_asset_blob_storage, upload_to=_get_asset_blob_prefix
     )
 
     created = models.DateTimeField(auto_now_add=True)
@@ -81,7 +81,7 @@ class Asset(models.Model):  # TODO: was NwbFile
             # local_path = Path(local_stream.name)
             sha256 = sha256_hasher.hexdigest()
 
-            blob = File(file=local_stream, name=girder_file.path.lstrip('/'),)
+            blob = File(file=local_stream, name=girder_file.path.lstrip('/'))
             # content_type is not part of the base File class (it on some other subclasses),
             # but regardless S3Boto3Storage will respect and use it, if it's set
             blob.content_type = 'application/octet-stream'

--- a/dandi/publish/models/dandiset.py
+++ b/dandi/publish/models/dandiset.py
@@ -18,7 +18,7 @@ class Dandiset(models.Model):
     GIRDER_ID_REGEX = r'[0-9a-f]{24}'
 
     draft_folder_id = models.CharField(
-        max_length=24, validators=[RegexValidator(f'^{GIRDER_ID_REGEX}$')],
+        max_length=24, validators=[RegexValidator(f'^{GIRDER_ID_REGEX}$')]
     )
 
     created = models.DateTimeField(auto_now_add=True)

--- a/dandi/publish/tests/factories.py
+++ b/dandi/publish/tests/factories.py
@@ -24,7 +24,7 @@ class DandisetFactory(factory.django.DjangoModelFactory):
     # DandisetFactory. This will call DraftVersionFactory(dandiset=our_new_dandiset), thus skipping
     # the SubFactory.
     draft_version = factory.RelatedFactory(
-        'dandi.publish.tests.factories.DraftVersionFactory', factory_related_name='dandiset',
+        'dandi.publish.tests.factories.DraftVersionFactory', factory_related_name='dandiset'
     )
 
 
@@ -51,7 +51,7 @@ class DraftVersionFactory(BaseVersionFactory):
 
     # Pass in draft_version=None to prevent DandisetFactory from creating another DraftVersion
     # (this disables the RelatedFactory).
-    dandiset = factory.SubFactory(DandisetFactory, draft_version=None,)
+    dandiset = factory.SubFactory(DandisetFactory, draft_version=None)
 
 
 class AssetFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
The latest version of Black treats these differently, and they don't make much sense to have.