### PR TITLE
Add search view

### DIFF
--- a/dandi/publish/tests/test_search.py
+++ b/dandi/publish/tests/test_search.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_search_no_query(api_client):
+    assert api_client.get('/api/search/').data == []
+
+
+@pytest.mark.django_db
+def test_search_empty_query(api_client):
+    assert api_client.get('/api/search/', {'search': ''}).data == []
+
+
+@pytest.mark.django_db
+def test_search_identifier(api_client, version):
+    resp = api_client.get('/api/search/', {'search': version.id}).data
+    assert len(resp) == 1
+    assert resp[0]['version'] == version.version
+    assert resp[0]['name'] == version.name

--- a/dandi/publish/views/__init__.py
+++ b/dandi/publish/views/__init__.py
@@ -1,6 +1,7 @@
 from .asset import AssetViewSet
 from .dandiset import DandisetViewSet
+from .search import search_view
 from .stats import stats_view
 from .version import VersionViewSet
 
-__all__ = ['AssetViewSet', 'DandisetViewSet', 'VersionViewSet', 'stats_view']
+__all__ = ['AssetViewSet', 'DandisetViewSet', 'VersionViewSet', 'search_view', 'stats_view']

--- a/dandi/publish/views/search.py
+++ b/dandi/publish/views/search.py
@@ -1,0 +1,31 @@
+from django.contrib.postgres.search import SearchVector
+from django.db.models import TextField
+from django.db.models.functions import Cast
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from dandi.publish.models import Version
+from dandi.publish.views.version import VersionSerializer
+
+
+@swagger_auto_schema(
+    method='GET',
+    manual_parameters=[
+        openapi.Parameter(
+            'search',
+            openapi.IN_QUERY,
+            description='Search published dandisets',
+            type=openapi.TYPE_STRING,
+        )
+    ],
+)
+@api_view()
+def search_view(request):
+    if 'search' not in request.query_params:
+        return Response([])
+    versions = Version.objects.annotate(search=SearchVector(Cast('metadata', TextField()))).filter(
+        search__contains=request.query_params['search']
+    )
+    return Response(VersionSerializer(versions, many=True).data)

--- a/dandi/urls.py
+++ b/dandi/urls.py
@@ -6,7 +6,13 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
-from dandi.publish.views import AssetViewSet, DandisetViewSet, VersionViewSet, stats_view
+from dandi.publish.views import (
+    AssetViewSet,
+    DandisetViewSet,
+    VersionViewSet,
+    search_view,
+    stats_view,
+)
 
 router = ExtendedSimpleRouter()
 (
@@ -41,6 +47,7 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('api/', include(router.urls)),
+    path('api/search/', search_view),
     path('api/stats/', stats_view),
     path('admin/', admin.site.urls),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),


### PR DESCRIPTION
A very quick and dirty search function to replace the one we are abandoning with Girder. It casts the metadata blob to a string and performs a Postgres text search on it. This is not a good solution, but it will "work" for now until we work out a proper search implementation.