### PR TITLE
Make dandiset sync swagger not require post body

### DIFF
--- a/dandi/publish/views/dandiset.py
+++ b/dandi/publish/views/dandiset.py
@@ -46,7 +46,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
         return super().get_object()
 
-    @action(detail=False, methods=['POST'])
+    @action(detail=False, methods=['POST'], serializer_class=None)
     def sync(self, request):
         if 'folder-id' not in request.query_params:
             raise ValidationError('Missing query parameter "folder-id"')


### PR DESCRIPTION
`drf_yasg` is checking the `serializer_class` of the sync view when determining the swagger arguments. When `serializer_class` is present and there is not an explicit schema specified, it assumes that there should be an `IN_BODY` argument of whatever the serializer handles.

The solution is to override the serializer to `None` on the sync view.